### PR TITLE
feat: encryption support

### DIFF
--- a/terraform/veda-wfs3/rds.tf
+++ b/terraform/veda-wfs3/rds.tf
@@ -58,6 +58,7 @@ resource "aws_db_instance" "db" {
   backup_retention_period  = 7
   username                 = "postgres"
   password                 = var.db_password
+  storage_encrypted        = var.db_encrypted
   allow_major_version_upgrade = true
   parameter_group_name     = aws_db_parameter_group.default.name
 }

--- a/terraform/veda-wfs3/variables.tf
+++ b/terraform/veda-wfs3/variables.tf
@@ -37,6 +37,12 @@ variable "db_password" {
   sensitive   = true
 }
 
+variable "db_encrypted" {
+  description = "Whether RDS storage should be encrypted"
+  type        = bool
+  default     = false
+}
+
 variable "dns_zone_name" {
 }
 


### PR DESCRIPTION
This PR addresses the requirement of certain high security environments to enable encryption of RDS tables. By default, encryption is off. It can be turned on by specifying `true` for the terraform variable `db_encrypted`.

I've avoided adding support for explicit KMS keys, as that's not strictly necessary without DB replication. If that ends up being desirable, it will look something like this:
```hocon
resource "aws_kms_key" "my_key" {
  description             = "KMS key for RDS encryption"
  deletion_window_in_days = 10
}

resource "aws_db_instance" "my_db" {
  storage_encrypted   = true
  kms_key_id          = aws_kms_key.my_key.arn
}
```

Closes #25 